### PR TITLE
Enable to optimze all github markdown files

### DIFF
--- a/src/website_list.json
+++ b/src/website_list.json
@@ -1268,8 +1268,8 @@
             ""
         ]
     },{
-        "name"    : "readme.github.com",
-        "url"     : "https://github.com/**/*/README*.md",
+        "name"    : "markdown.github.com",
+        "url"     : "https://github.com/**/*/*.md",
         "title"   : "[[{$('title').text()}]]",
         "desc"    : "",
         "include" : "<article class='markdown-body'>",


### PR DESCRIPTION
Github 上面有很多仓库不止 README 文件是 markdown 格式，比如 [You-Dont-Know-JS](https://github.com/getify/You-Dont-Know-JS) 这个库。这样其它非 README 文件也可以进入阅读模式。