### PR TITLE
add suport onenotebusiness

### DIFF
--- a/src/module/authorize.jsx
+++ b/src/module/authorize.jsx
@@ -200,7 +200,7 @@ export default class Auth extends React.Component {
                 onenote.dtd.done( ()=> {
                     onenote.Auth( ( result, error ) => {
                         if ( error ) failed( error, onenote.id, onenote.name );
-                        else success( onenote.id, onenote.name, { access_token: onenote.access_token });
+                        else success( onenote.id, onenote.name, { access_token: onenote.access_token, refresh_token: onenote.refresh_token });
                     });
                 }).fail( error => failed( error, onenote.id, onenote.name ));
                 break;

--- a/src/service/export.js
+++ b/src/service/export.js
@@ -686,13 +686,15 @@ class Onenote {
     }
 
     get scopes() {
-        return [ "office.onenote_create" ];
+        return [ "Notes.Create", "Notes.Read", "Notes.ReadWrite" ];
+        // return [ "office.onenote_create" ];
     }
 
     New() {
         this.dtd  = $.Deferred();
         this.code = "";
         this.access_token = "";
+        this.onte_type = "";
         return this;
     }
 
@@ -715,7 +717,8 @@ class Onenote {
     }
 
     Login() {
-        let url = "https://login.live.com/oauth20_authorize.srf?";
+        // let url = "https://login.live.com/oauth20_authorize.srf?";
+        let url = "https://login.microsoftonline.com/common/oauth2/v2.0/authorize?";
         const params = {
             client_id    : this.client_id,
             redirect_uri : this.redirect_uri,
@@ -731,6 +734,7 @@ class Onenote {
 
     Accesstoken( url ) {
         url = url.replace( "http://ksria.com/simpread/auth.html?", "" );
+        url = url.split( "&session_state")[0]
         if ( url.startsWith( "code" ) ) {
             this.code = url.replace( "code=", "" );
             this.dtd.resolve();
@@ -741,7 +745,8 @@ class Onenote {
 
     Auth( callback ) {
         $.ajax({
-            url     : "https://login.live.com/oauth20_token.srf",
+            // url     : "https://login.live.com/oauth20_token.srf",
+            url     : "https://login.microsoftonline.com/common/oauth2/v2.0/token",
             type    : "POST",
             headers : {
                 "Content-Type": "application/x-www-form-urlencoded"
@@ -752,6 +757,7 @@ class Onenote {
                 code          : this.code,
                 grant_type    : "authorization_code",
                 redirect_uri  : this.redirect_uri,
+                scope         : this.scopes.join( " " ),
             }
         }).done( ( result, textStatus, jqXHR ) => {
             if ( result ) {
@@ -768,11 +774,12 @@ class Onenote {
 
     Add( html, callback ) {
         $.ajax({
-            url     : "https://www.onenote.com/api/v1.0/me/notes/pages",
+            url     : "https://graph.microsoft.com/v1.0/me/onenote/pages?sectionName=简阅",
             type    : "POST",
             headers : {
                 "Content-Type": "application/xhtml+xml",
-                "Authorization": `Bearer ${this.access_token}`
+                "Authorization": `Bearer ${this.access_token}`,
+                "Accept-Language": "en;q=0.8,en-US;q=0.6"
             },
             data    : html,
         }).done( ( result, status, xhr ) => {


### PR DESCRIPTION
支持了导出到OneNoteBuiness。以前的版本无法对接到商业版。层级结构模仿官方微信公众号推送到默认笔记本下的微信保存，简阅是创建一个简阅分区。以下是商业版和个人版操作截图，已自验，可正常推送。
![image](https://user-images.githubusercontent.com/16175551/100597435-6d4ed480-3338-11eb-8361-3db634c2f563.png)
![image](https://user-images.githubusercontent.com/16175551/100597455-717af200-3338-11eb-8615-78ef2cc759c2.png)
