### PR TITLE
[WIP]Update sites

### DIFF
--- a/src/website_list.json
+++ b/src/website_list.json
@@ -237,7 +237,7 @@
         "desc"    : "[[{$('meta[name=description]').attr('content')}]]",
         "include" : "[[[$('.articleWidth-content').find('.content')]]]",
         "exclude" : [
-            "[[{(function(){var author=$('.article-author .author-item').children('a').clone();var time=$('.article-author .timer').text();var banner=$('.article-banner').clone();author=$('<p>作者：</p>').append(author);time=$('<p>时间：</p>').append(time);$('sr-rd-content').prepend(time).prepend(author).prepend(banner);}())}]]",
+            "[[{(function(){var author=$('.author-item').children('a').clone();var time=$('.article-author .timer').text();var banner=$('.article-banner').clone();author=$('<p>作者：</p>').append(author);time=$('<p>时间：</p>').append(time);$('sr-rd-content').prepend(time).prepend(author).prepend(banner);}())}]]",
             "<img id='s1' >",
             "<hr>",
             "[['<span>我们主张分享真实的产品体验</span>']]",

--- a/src/website_list.json
+++ b/src/website_list.json
@@ -309,7 +309,7 @@
             {"url"  : "[[{$('.AuthorInfo-avatar')}]]"}
         ],
         "title"   : "[[{$('main .QuestionHeader-main').find('h1').text()}]]",
-        "desc"    : "",
+        "desc"    : "[[{(function(){var questions=JSON.parse($('#js-initialData').text()).initialState.entities.questions;var detail='';for(const id in questions){detail=questions[id].detail;break;};detail=detail.replaceAll('。','.').replace(/\\.$/,'。');return $('<p>').append(detail).text();}())}]]",
         "include" : "[[{$('.RichContent-inner')}]]",
         "exclude" : [
             "[[{(function(){$('sr-rd-content figure noscript').each(function(){var noscript = $(this).text();if(noscript.match(/<img/)) {var img = $(this).parent().empty().append(noscript).find('img');var src = img.attr('src') || '';if(src.match(/.gif/)) img.attr('real_src',src);}});}())}]]",

--- a/src/website_list.json
+++ b/src/website_list.json
@@ -237,6 +237,7 @@
         "desc"    : "[[{$('meta[name=description]').attr('content')}]]",
         "include" : "[[[$('.articleWidth-content').find('.content')]]]",
         "exclude" : [
+            "[[{(function(){var author=$('.article-author .author-item').children('a').clone();var time=$('.article-author .timer').text();var banner=$('.article-banner').clone();author=$('<p>作者：</p>').append(author);time=$('<p>时间：</p>').append(time);$('sr-rd-content').prepend(time).prepend(author).prepend(banner);}())}]]",
             "<img id='s1' >",
             "<hr>",
             "[['<span>我们主张分享真实的产品体验</span>']]",


### PR DESCRIPTION
更新适配：

- 少数派文章页面，增加捕捉题图、作者和发布日期 #1668 
   - 单个作者
   示例页面： https://sspai.com/post/64027
   ![image](https://user-images.githubusercontent.com/5285894/104361477-76dd7600-554d-11eb-91e0-be37d1ae6e5d.png)
   - 多个作者
   示例页面： https://sspai.com/post/64304
   ![image](https://user-images.githubusercontent.com/5285894/104364831-1f8dd480-5552-11eb-94f9-1aedc45be48f.png)

- 知乎问答页面，优化提取问题内容的规则 （以前写的太烂，代码难以阅读被Kenshin删除了，这次重新优化了，可读性好一些）