### PR TITLE
Add websites: gushiwen

### DIFF
--- a/src/website_list.json
+++ b/src/website_list.json
@@ -3522,9 +3522,10 @@
         ]
     },{
         "name"    : "so.gushiwen.org",
-        "url"     : "http*://so.gushiwen.org/**.aspx",
+        "url"     : "http*://so.gushiwen.org/**/*.aspx",
         "title"   : "<title>",
-        "desc"    : "[[[(function(){left=$('.main3 .left');['译文','赏析','注释'].forEach(text=>{left.find(`img[alt='${text}']`).click();});left.find(\"div a:contains('展开阅读全文')\").each((i,e)=>{e.click()});return $('.main3 .left').children().eq(0).nextUntil('.title');}())]]]",
+        "desc"    : "[[{$('meta[name=Description]').attr('content')||$('meta[name=description]').attr('content')}]]",
+        "include"    : "[[[(function(){left=$('.main3 .left');['译文','赏析','注释'].forEach(text=>{left.find(`img[alt='${text}']`).click();});left.find(\"div a:contains('展开阅读全文')\").each((i,e)=>{e.click()});return $('.main3 .left').children().eq(0).nextUntil('.title');}())]]]",
         "exclude" : [
             "[[[$('.yizhu')]]]",
             "[[[$('.tool')]]]",

--- a/src/website_list.json
+++ b/src/website_list.json
@@ -3521,6 +3521,18 @@
             "[[{(function(){var e=$('sr-rd-content'); var content=e.html();content=content.replaceAll(/<!--[^<]*-->/g,'');e.html(content);}())}]]"
         ]
     },{
+        "name"    : "so.gushiwen.org",
+        "url"     : "http*://so.gushiwen.org/**.aspx",
+        "title"   : "<title>",
+        "desc"    : "[[[(function(){left=$('.main3 .left');['译文','赏析','注释'].forEach(text=>{left.find(`img[alt='${text}']`).click();});left.find(\"div a:contains('展开阅读全文')\").each((i,e)=>{e.click()});return $('.main3 .left').children().eq(0).nextUntil('.title');}())]]]",
+        "exclude" : [
+            "[[[$('.yizhu')]]]",
+            "[[[$('.tool')]]]",
+            "[[[$('a[href$=\")\"]')]]]",
+            "[[[$('div textarea')]]]"
+        ],
+        "css"     : ""
+    },{
         "name"    : "bbs.pediy.com",
         "url"     : "http*://bbs.pediy.com/thread-*",
         "title"   : "[[{$('meta[name=keywords]').attr('content')||$('meta[name=description]').attr('content')}]]",

--- a/src/website_list.json
+++ b/src/website_list.json
@@ -3525,14 +3525,13 @@
         "url"     : "http*://so.gushiwen.org/**/*.aspx",
         "title"   : "<title>",
         "desc"    : "[[{$('meta[name=Description]').attr('content')||$('meta[name=description]').attr('content')}]]",
-        "include"    : "[[[(function(){left=$('.main3 .left');['译文','赏析','注释'].forEach(text=>{left.find(`img[alt='${text}']`).click();});left.find(\"div a:contains('展开阅读全文')\").each((i,e)=>{e.click()});return $('.main3 .left').children().eq(0).nextUntil('.title');}())]]]",
+        "include" : "[[[(function(){left=$('.main3 .left');['译文','赏析','注释'].forEach(text=>{left.find(`img[alt='${text}']`).click();});left.find(\"div a:contains('展开阅读全文')\").each((i,e)=>{e.click()});return $('.main3 .left').children().eq(0).nextUntil('.title');}())]]]",
         "exclude" : [
             "[[[$('.yizhu')]]]",
             "[[[$('.tool')]]]",
             "[[[$('a[href$=\")\"]')]]]",
             "[[[$('div textarea')]]]"
-        ],
-        "css"     : ""
+        ]
     },{
         "name"    : "bbs.pediy.com",
         "url"     : "http*://bbs.pediy.com/thread-*",


### PR DESCRIPTION
新增适配：
- 古诗文网 #1949

This closes Kenshin/simpread#1949, closes Kenshin/simpread#310

----

可通过添加第三方适配源 `https://raw.githubusercontent.com/binsee/simpread/update-sites-gushiwen/src/website_list.json`

### 测试页面：

- 卷耳原文、翻译及赏析_古诗_古诗文网
https://so.gushiwen.org/shiwenv_63579de8b4d8.aspx

- "日暖泥融雪半消，行人芳草马声骄。"全诗赏析_古诗文网
https://so.gushiwen.org/mingju/juv_49ab7b66ed43.aspx
