### PR TITLE
update websites - infoq.cn

### DIFF
--- a/src/website_list.json
+++ b/src/website_list.json
@@ -1033,60 +1033,12 @@
         ]
     },{
         "name"    : "infoq.cn",
-        "url"     : "http*://www.infoq.cn/article/*",
-        "title"   : "<title>",
-        "desc"    : "",
-        "include" : "<div class='article-content'>",
-        "exclude" : [
-            ""
-        ]
-    },{
-        "name"    : "xie.infoq.cn",
-        "url"     : "http*://xie.infoq.cn/article/*",
+        "url"     : "http*://*.infoq.cn/*/*",
         "title"   : "<title>",
         "desc"    : "[[{$('meta[name=Description]').attr('content')||$('meta[name=description]').attr('content')}]]",
-        "include" : "[[[(function(){var wrap = $('.preview-wrap');if(!wrap.length) {wrap = $('<p>异步加载型页面，本次未能获取到内容元素，请重新进入阅读模式尝试</p><br><p>'+''.padEnd(100,'#')+'</p>');$('head').append(wrap);}return wrap;}())]]]",
+        "include" : "[[[(function(){var wrap = $('.article-preview,.article-typo');if(!wrap.length) {wrap = $('<p>异步加载型页面，本次未能获取到内容元素。<br>请将 http*://*.infoq.cn/*/* 加入延迟加载列表后，刷新页面后手动进入阅读模式尝试</p><br><p>'+''.padEnd(100,'#')+'</p>');$('head').append(wrap);}return wrap;}())]]]",
         "exclude" : [
             ""
-        ]
-    },{
-        "name"    : "infoq.com",
-        "url"     : "http://www.infoq.com/cn/articles/",
-        "title"   : "<title>",
-        "desc"    : "",
-        "include" : "<div class='text_info_article'>",
-        "exclude" : [
-            "<div class='random_links'>",
-            "<div id='comment_here'>",
-            "<div class='comments'>",
-            "<div class='all_comments'>",
-            "<div id='overlay_comments'>",
-            "<div id='replyPopup'>",
-            "<div id='editCommentPopup'>",
-            "<div id='messagePopup'>",
-            "<div id='responseContent'>",
-            "<div class='related'>",
-            "<div class='comment_here'>",
-            "<script>",
-            "<div class='all_comments'>",
-            "<div class='comments'>",
-            "[['<p>对本文的审校</p>']]",
-            "[['<p>中文站投稿或者参与内容翻译工作</p>']]",
-            "[['<b>QCon北京2017</b>']]"
-        ]
-    },{
-        "name"    : "news.infoq.com",
-        "url"     : "http://www.infoq.com/cn/news/**/*",
-        "title"   : "<h1 class='general'>",
-        "desc"    : "",
-        "include" : "<div class='text_info'>",
-        "exclude" : [
-            "<div class='random_links'>",
-            "<div class='related'>",
-            "<div class='comment_here'>",
-            "<script>",
-            "<div class='all_comments'>",
-            "<div class='comments'>"
         ]
     },{
         "name"    : "segmentfault.com",

--- a/src/website_list.json
+++ b/src/website_list.json
@@ -1036,7 +1036,7 @@
         "url"     : "http*://*.infoq.cn/*/*",
         "title"   : "<title>",
         "desc"    : "[[{$('meta[name=Description]').attr('content')||$('meta[name=description]').attr('content')}]]",
-        "include" : "[[[(function(){var wrap = $('.article-preview,.article-typo');if(!wrap.length) {wrap = $('<p>异步加载型页面，本次未能获取到内容元素。<br>请将 http*://*.infoq.cn/*/* 加入延迟加载列表后，刷新页面后手动进入阅读模式尝试</p><br><p>'+''.padEnd(100,'#')+'</p>');$('head').append(wrap);}return wrap;}())]]]",
+        "include" : "[[[(function(){var wrap = $('.article-preview,.article-typo');if(!wrap.length) {wrap = $('<p>异步加载型页面，本次未能获取到内容元素。<br>请将 infoq.cn 加入排除列表后，刷新页面后手动进入阅读模式尝试</p><br><p>'+''.padEnd(100,'#')+'</p>');$('head').append(wrap);}return wrap;}())]]]",
         "exclude" : [
             ""
         ]

--- a/src/website_list.json
+++ b/src/website_list.json
@@ -1033,7 +1033,7 @@
         ]
     },{
         "name"    : "infoq.cn",
-        "url"     : "http*://*.infoq.cn/*/*",
+        "url"     : "http*://*.infoq.cn/**/*",
         "title"   : "<title>",
         "desc"    : "[[{$('meta[name=Description]').attr('content')||$('meta[name=description]').attr('content')}]]",
         "include" : "[[[(function(){var wrap = $('.article-preview,.article-typo');if(!wrap.length) {wrap = $('<p>异步加载型页面，本次未能获取到内容元素。<br>请将 infoq.cn 加入排除列表后，刷新页面并手动进入阅读模式尝试</p><br><p>'+''.padEnd(100,'#')+'</p>');$('head').append(wrap);}return wrap;}())]]]",

--- a/src/website_list.json
+++ b/src/website_list.json
@@ -1036,7 +1036,7 @@
         "url"     : "http*://*.infoq.cn/*/*",
         "title"   : "<title>",
         "desc"    : "[[{$('meta[name=Description]').attr('content')||$('meta[name=description]').attr('content')}]]",
-        "include" : "[[[(function(){var wrap = $('.article-preview,.article-typo');if(!wrap.length) {wrap = $('<p>异步加载型页面，本次未能获取到内容元素。<br>请将 infoq.cn 加入排除列表后，刷新页面后手动进入阅读模式尝试</p><br><p>'+''.padEnd(100,'#')+'</p>');$('head').append(wrap);}return wrap;}())]]]",
+        "include" : "[[[(function(){var wrap = $('.article-preview,.article-typo');if(!wrap.length) {wrap = $('<p>异步加载型页面，本次未能获取到内容元素。<br>请将 infoq.cn 加入排除列表后，刷新页面并手动进入阅读模式尝试</p><br><p>'+''.padEnd(100,'#')+'</p>');$('head').append(wrap);}return wrap;}())]]]",
         "exclude" : [
             ""
         ]


### PR DESCRIPTION
- remove invalid rules for infoq.com/cn
- update infoq.cn

适用于 `infoq.cn` 全站文章页：

- InfoQ写作平台的文章页，例如 https://xie.infoq.cn/article/f859764824f443776bc95fd1e
- InfoQ新闻文章页，例如 https://www.infoq.cn/news/2017/07/ArchSummit-Shenzhen-2017-held
- InfoQ平台文章页，例如 https://www.infoq.cn/article/distributed-tracing-microservices/
- InfoQ电子书页面，例如 https://www.infoq.cn/minibook/a3yifEYgJEchO0qBkxEd
- InfoQ直播页面，例如 https://live.infoq.cn/room/877
- InfoQ话题文章页，例如 https://www.infoq.cn/talk/uMUMNa5INpOI3a3bvtCJ
- InfoQ视频页，例如 https://www.infoq.cn/video/WvEN9x6YGzROSDTpjkKV

### 注意事项

由于 `InfoQ` 站点是异步加载文章内容，因此需要将 `infoq.cn` 加入到 **排除列表**。（关于为什么添加到`排除列表`，而非 `延迟加载列表`，见 https://github.com/Kenshin/simpread/issues/1074#issuecomment-845060823 ）
添加到排除列表后，再打开文章页时，按快捷键 `A A` 进入阅读模式即可。
如未添加到排除列表，因自动进入阅读模式时文章实际内容未加载，会提示错误。

### 测试用适配源

> https://gist.githubusercontent.com/binsee/55acad05b921ba79ac6695a9463f563c/raw/infoq.cn.json

在此pr合并前，可将上述url加入第三方适配源中，打开上述测试页面测试效果。如果进入阅读模式出错，请在站点中选择`第三方适配源`以启用本适配，而非简悦官方规则中的失效适配
注意pr合并后，请将上述url从第三方适配源中移除，避免后续出问题。

### 效果演示视频

https://user-images.githubusercontent.com/5285894/119101639-c6780500-ba4b-11eb-9c1d-4fca883695aa.mp4

### 相关issues

#2035 #2190