### PR TITLE
update websites - colah.github.io

### DIFF
--- a/src/website_list.json
+++ b/src/website_list.json
@@ -3542,5 +3542,15 @@
             ""
         ],
         "css"     : ".simpread-read-root {align-items: baseline;}"
+    },{
+        "name"    : "colah.github.io",
+        "url"     : "http*://colah.github.io/posts/*",
+        "title"   : "<title>",
+        "desc"    : "[[{$('meta[name=Description]').attr('content')||$('meta[name=description]').attr('content')}]]",
+        "include" : "[[[$('.col-md-8')]]]",
+        "exclude" : [
+            "[[[$('sr-rd-content style').nextAll()]]]",
+            "[[[$('sr-rd-content div:first').next().prevAll()]]]"
+        ]
     }]
 }

--- a/src/website_list.json
+++ b/src/website_list.json
@@ -3544,13 +3544,14 @@
         "css"     : ".simpread-read-root {align-items: baseline;}"
     },{
         "name"    : "colah.github.io",
-        "url"     : "http*://colah.github.io/posts/*",
+        "url"     : "http*://colah.github.io/posts/**",
         "title"   : "<title>",
         "desc"    : "[[{$('meta[name=Description]').attr('content')||$('meta[name=description]').attr('content')}]]",
-        "include" : "[[[$('.col-md-8')]]]",
+        "include" : "[[[(()=>{let body=$('.col-md-8 #body');if(!body.length){body=$('.col-md-8')};return body})()]]]",
         "exclude" : [
-            "[[[$('sr-rd-content style').nextAll()]]]",
-            "[[[$('sr-rd-content div:first').next().prevAll()]]]"
+            "[[[$('sr-rd-content h1:first').next().prevAll()]]]",
+            "[[[$('sr-rd-content .footnotes').nextAll()]]]",
+            "[[[$('sr-rd-content .main-disqussion-link-wrp').prev().nextAll()]]]"
         ]
     }]
 }


### PR DESCRIPTION
### 适配列表

- 博客 [colah.github.io](https://colah.github.io/)

#### 测试页面

- http://colah.github.io/posts/2015-08-Understanding-LSTMs/
- https://colah.github.io/posts/2014-07-NLP-RNNs-Representations/
- https://colah.github.io/posts/2020-05-University/

### 注意事项

由于 `colah.github.io` 站点部分文章内含公式等特殊格式，是动态渲染的，因此需要将 `colah.github.io` 加入到 **排除列表**。（关于为什么添加到`排除列表`，而非 `延迟加载列表`，见 https://github.com/Kenshin/simpread/issues/1074#issuecomment-845060823 ）
添加到排除列表后，再打开文章页时，按快捷键 `A A` 进入阅读模式即可。
如未添加到排除列表，因自动进入阅读模式时公式可能未处理完毕，会显示异常，如`\(A\)`。

### 测试用适配源

> https://gist.githubusercontent.com/binsee/55acad05b921ba79ac6695a9463f563c/raw/colah.github.io.json

在此pr合并前，可将上述url加入第三方适配源中，打开上述测试页面测试效果。如果进入阅读模式出错，请在站点中选择`第三方适配源`以启用本适配，而非简悦官方规则中的失效适配
注意pr合并后，请将上述url从第三方适配源中移除，避免后续出问题。

### 效果图示

![image](https://user-images.githubusercontent.com/5285894/119282702-4204cc80-bc6d-11eb-8836-27eed71859aa.png)

### 相关issues

#1961 #413 #1905

PS: 这个站太乱了，各页面结构不一致，即使尽量做了兼容，但部分页面的非正文部分无法完全剔除。
PS2：这个站自身文章并不多，没有太大合并的必要性。可以自行填写第三方适配源，或者之后发布到 `站点集市` （待审核，ID： `o5rx7zi0-GnP7PBUlSC` ）